### PR TITLE
Add new npm script and add link to feeding component

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -127,5 +127,8 @@
       }
     }
   },
-  "defaultProject": "lordgasmic-webapp"
+  "defaultProject": "lordgasmic-webapp",
+  "cli": {
+    "analytics": false
+  }
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
+    "build-prod":"ng build --prod=true",
     "build": "ng build",
     "test": "ng test",
     "lint": "ng lint",

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,1 +1,2 @@
 <router-outlet></router-outlet>
+<a href="/feeding" routerLink="/feeding">Thing</a>


### PR DESCRIPTION
so what i did to test: 
* I built a prod bundle using `npm run build-prod`. check the package.json to see the command.
* Then I used a global static server to just host that dir. https://www.npmjs.com/package/serve is an example.
* If you navigate straight to the route you get an error this way, however i made a link on the home page to link thru. 

Not saying to merge this in, but take a look at what i did for troubleshooting :) hope this help!